### PR TITLE
Feature/not fail on receiving with unknown ocpp properties

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/JsonObjectMapper.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/JsonObjectMapper.java
@@ -30,6 +30,7 @@ import de.rwth.idsg.steve.ocpp.ws.ocpp16.Ocpp16JacksonModule;
 
 import static com.fasterxml.jackson.core.JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 /**
  * Because ObjectMapper can and should be reused, if config does not change after init.
@@ -56,6 +57,8 @@ public enum JsonObjectMapper {
         mapper.configure(FAIL_ON_NULL_FOR_PRIMITIVES, true);
 
         mapper.configure(WRITE_BIGDECIMAL_AS_PLAIN, true);
+
+        mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         mapper.registerModule(new CustomStringModule());
         mapper.registerModule(new Ocpp12JacksonModule());


### PR DESCRIPTION
some of our customers's CP added custom ocpp fields(properties) in their request from CP or response, mostly for debug or exception handling, making the steve ocpp server not working as expected.
=>So I made it not to fail on receiving with unknown ocpp properties

linked changes

テスト：

修正前：

INFO:ocpp:CP1: send [2,"e8960cb7-6434-457f-9fac-e6c1c2992896","BootNotification",{"chargePointModel":"MY-MODEL","chargePointVendor":"MY-VENDOR","chargePointSerialNumber":"MY-SERIAL-001","customProperty":"unexpected_property"}]
INFO:ocpp:CP1: receive message [4,"e8960cb7-6434-457f-9fac-e6c1c2992896","FormationViolation","The payload for action could not be deserialized",{"errorMsg":"Unrecognized field \"customProperty\" (class ocpp.cs._2015._10.BootNotificationRequest), not marked as..."}]
WARNING:ocpp:Received a CALLError: <CallError - unique_id=e8960cb7-6434-457f-9fac-e6c1c2992896, error_code=FormationViolation, error_description=The payload for action could not be deserialized, error_details={'errorMsg': 'Unrecognized field "customProperty" (class ocpp.cs._2015._10.BootNotificationRequest), not marked as...'}>'

修正後：

INFO:ocpp:CP1: send [2,"f4240eae-95f3-4f35-9401-481669db40c9","BootNotification",{"chargePointModel":"MY-MODEL","chargePointVendor":"MY-VENDOR","chargePointSerialNumber":"MY-SERIAL-001","customProperty":"unexpected_property"}]
INFO:ocpp:CP1: receive message [3,"f4240eae-95f3-4f35-9401-481669db40c9",{"status":"Accepted","currentTime":"2024-05-27T07:01:54.216Z","interval":14400}]
